### PR TITLE
GPIO for all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ OPT_LINKALL = -DLINKALL
 OPT_RESAMPLE= -DRESAMPLE
 OPT_VIS     = -DVISEXPORT
 OPT_IR      = -DIR
+OPT_GPIO    = -DGPIO
 
 SOURCES = \
 	main.c slimproto.c buffer.c stream.c utils.c \
@@ -21,6 +22,7 @@ SOURCES_FF       = ffmpeg.c
 SOURCES_RESAMPLE = process.c resample.c
 SOURCES_VIS      = output_vis.c
 SOURCES_IR       = ir.c
+SOURCES_GPIO     = gpio.c
 
 LINK_LINUX       = -ldl
 
@@ -48,6 +50,9 @@ ifneq (,$(findstring $(OPT_VIS), $(CFLAGS)))
 endif
 ifneq (,$(findstring $(OPT_IR), $(CFLAGS)))
 	SOURCES += $(SOURCES_IR)
+endif
+ifneq (,$(findstring $(OPT_GPIO), $(CFLAGS)))
+	SOURCES += $(SOURCES_GPIO)
 endif
 
 # add optional link options

--- a/gpio.c
+++ b/gpio.c
@@ -25,16 +25,19 @@
 #if GPIO
 
 #include "squeezelite.h"
+#ifdef __WIRING_PI_H__
 #include <wiringPi.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 
-int gpio_state = -1;
-int initialized = -1;
-int power_state = -1;
+static int gpio_state = -1;
+static int initialized = -1;
+static int power_state = -1;
 
 void relay( int state) {
+#ifdef __WIRING_PI_H__
     gpio_state = state;
 
   // Set up gpio  using BCM Pin #'s
@@ -49,6 +52,7 @@ void relay( int state) {
     else if(gpio_state == 0)
         digitalWrite(gpio_pin, LOW^gpio_active_low);
     // Done!
+#endif
 }
 
 char *cmdline;

--- a/main.c
+++ b/main.c
@@ -70,7 +70,7 @@ static void usage(const char *argv0) {
 #else
 		   "  -d <log>=<level>\tSet logging level, logs: all|slimproto|stream|decode|output|ir, level: info|debug|sdebug\n"
 #endif
-#if GPIO
+#if GPIO && __WIRING_PI_H__
 		   "  -G <Rpi GPIO#>:<H/L>\tSpecify the BCM GPIO# to use for Amp Power Relay and if the output should be Active High or Low\n"
 #endif
 		   "  -e <codec1>,<codec2>\tExplicitly exclude native support of one or more codecs; known codecs: " CODECS "\n"
@@ -317,8 +317,11 @@ int main(int argc, char **argv) {
 #if IR
 						  "i"
 #endif
+#if GPIO && __WIRING_PI_H__
+						  "G"
+#endif
 #if GPIO
-						  "GS"
+						  "S"
 #endif
 
 						  , opt)) {
@@ -528,7 +531,7 @@ int main(int argc, char **argv) {
 			}
 			break;
 #endif
-#if GPIO
+#if GPIO && __WIRING_PI_H__
 		case 'G':
 			if (power_script != NULL){
 				fprintf(stderr, "-G and -S options cannot be used together \n\n" );
@@ -561,6 +564,8 @@ int main(int argc, char **argv) {
 				exit(1);
 			}
 			break;
+#endif
+#if GPIO
 		case 'S':
 			if (gpio_active){
 				fprintf(stderr, "-G and -S options cannot be used together \n\n" );


### PR DESCRIPTION
Made the Raspberry Pi specific code dependent on presence of
**WIRING_PI_H**. State scripts can now function on all platforms.
