### PR TITLE
Include default server in discovery

### DIFF
--- a/slimproto.c
+++ b/slimproto.c
@@ -782,11 +782,12 @@ void wake_controller(void) {
 	wake_signal(wake_e);
 }
 
-in_addr_t discover_server(void) {
+in_addr_t discover_server(char *default_server) {
 	struct sockaddr_in d;
 	struct sockaddr_in s;
 	char *buf;
 	struct pollfd pollinfo;
+	unsigned port;
 
 	int disc_sock = socket(AF_INET, SOCK_DGRAM, 0);
 
@@ -817,6 +818,10 @@ in_addr_t discover_server(void) {
 			socklen_t slen = sizeof(s);
 			recvfrom(disc_sock, readbuf, 10, 0, (struct sockaddr *)&s, &slen);
 			LOG_INFO("got response from: %s:%d", inet_ntoa(s.sin_addr), ntohs(s.sin_port));
+		}
+		
+		if(default_server) {
+			server_addr(default_server, &s.sin_addr.s_addr, &port);
 		}
 
 	} while (s.sin_addr.s_addr == 0 && running);
@@ -849,7 +854,7 @@ void slimproto(log_level level, char *server, u8_t mac[6], const char *name, con
 	}
 
 	if (!slimproto_ip) {
-		slimproto_ip = discover_server();
+		slimproto_ip = discover_server(server);
 	}
 
 	if (!slimproto_port) {
@@ -924,7 +929,7 @@ void slimproto(log_level level, char *server, u8_t mac[6], const char *name, con
 
 			// rediscover server if it was not set at startup
 			if (!server && ++failed_connect > 5) {
-				slimproto_ip = serv_addr.sin_addr.s_addr = discover_server();
+				slimproto_ip = serv_addr.sin_addr.s_addr = discover_server(NULL);
 			}
 
 		} else {


### PR DESCRIPTION
Allow reconnect to default server during discovery instead of ignoring
it after initial fail to connect.
