### PR TITLE
Tidal via Mysqueezebox.com: fix for wrong format announcement

### DIFF
--- a/squeezelite.h
+++ b/squeezelite.h
@@ -527,6 +527,7 @@ void decode_close(void);
 void decode_flush(void);
 unsigned decode_newstream(unsigned sample_rate, unsigned supported_rates[]);
 void codec_open(u8_t format, u8_t sample_size, u8_t sample_rate, u8_t channels, u8_t endianness);
+void codec_verify(u8_t format);
 
 #if PROCESS
 // process.c

--- a/stream.c
+++ b/stream.c
@@ -79,6 +79,7 @@ static void _disconnect(stream_state state, disconnect_code disconnect) {
 }
 
 static void *stream_thread() {
+	const char *flac_header = "Content-Type: audio/flac";
 
 	while (running) {
 
@@ -178,6 +179,9 @@ static void *stream_thread() {
 						if (endtok == 4) {
 							*(stream.header + stream.header_len) = '\0';
 							LOG_INFO("headers: len: %d\n%s", stream.header_len, stream.header);
+							if(strstr(stream.header, flac_header) != NULL) {
+								codec_verify('f');
+							}
 							stream.state = stream.cont_wait ? STREAMING_WAIT : STREAMING_BUFFERING;
 							wake_controller();
 						}


### PR DESCRIPTION
Occasionally, while using Tidal via mysqueezebox.com, the wrong format
is announced. While a flac file is server, mp3 is announced. Therefore
the wrong codec is loaded. This implements a double check for
